### PR TITLE
fix typo

### DIFF
--- a/chameleon/download_data.py
+++ b/chameleon/download_data.py
@@ -2,9 +2,9 @@
 # This software may be used and distributed according to the terms of the Chameleon License Agreement.
 
 import hashlib
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 
 
 def download_file(url: str, output_path: Path):

--- a/chameleon/inference/chameleon.py
+++ b/chameleon/inference/chameleon.py
@@ -81,9 +81,9 @@ class Options:
     extra_eos_tokens: list[int | str] = field(default_factory=lambda: ["<racm3:break>"])
 
     def __post_init__(self):
-        if self.txt:
+        if self.txt is True:
             self.txt = Options.Text()
-        if self.img:
+        if self.img is True:
             self.img = Options.Image()
 
 

--- a/chameleon/inference/chameleon.py
+++ b/chameleon/inference/chameleon.py
@@ -81,9 +81,9 @@ class Options:
     extra_eos_tokens: list[int | str] = field(default_factory=lambda: ["<racm3:break>"])
 
     def __post_init__(self):
-        if self.txt == True:
+        if self.txt:
             self.txt = Options.Text()
-        if self.img == True:
+        if self.img:
             self.img = Options.Image()
 
 
@@ -146,7 +146,7 @@ class TokenManager:
             if input_["type"] == "text":
                 tokens += self.tokenize_text(input_["value"])
             elif input_["type"] == "image":
-                if type(input_["value"]) == str:
+                if isinstance(input_["value"], str):
                     if input_["value"].startswith("data:"):
                         # Value Format: 'data:image/[^;]+;base64,[A-Za-z0-9+/]+={0,2}'
                         tokens += self.tokenize_b64img(input_["value"].split(",", 1)[1])
@@ -156,7 +156,7 @@ class TokenManager:
                         )
                     else:
                         raise ValueError("Unknown image format.")
-                elif type(input_["value"]) == Image:
+                elif isinstance(input_["value"], Image):
                     tokens += self.tokenize_image(input_["value"])
                 else:
                     raise ValueError("Unknown image type.")

--- a/chameleon/viewer/backend/data_types.py
+++ b/chameleon/viewer/backend/data_types.py
@@ -9,8 +9,6 @@ from typing import Literal
 from pydantic import BaseModel, Extra, Field
 
 from chameleon.viewer.backend.models.abstract_model import (
-    DEFAULT_IMAGE_CFG_IMAGE,
-    DEFAULT_IMAGE_CFG_TEXT,
     DEFAULT_MULTIMODAL_CFG_IMAGE,
     DEFAULT_MULTIMODAL_CFG_TEXT,
 )

--- a/chameleon/viewer/backend/model_viewer.py
+++ b/chameleon/viewer/backend/model_viewer.py
@@ -3,17 +3,17 @@
 # This source code is licensed under the Chameleon License found in the
 # LICENSE file in the root directory of this source tree.
 
-from pathlib import Path
-
 import hydra
 import torch
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
 
-from chameleon.viewer.backend.models.service import serve
-from chameleon.viewer.backend.models.chameleon_distributed import ChameleonDistributedGenerator
-from chameleon.viewer.backend.models.chameleon_local import ChameleonLocalGenerator
-from chameleon.viewer.backend.utils import configure_rich_logging, get_logger
 from chameleon.inference import loader
+from chameleon.viewer.backend.models.chameleon_distributed import (
+    ChameleonDistributedGenerator,
+)
+from chameleon.viewer.backend.models.chameleon_local import ChameleonLocalGenerator
+from chameleon.viewer.backend.models.service import serve
+from chameleon.viewer.backend.utils import configure_rich_logging, get_logger
 
 logger = get_logger(__name__)
 

--- a/chameleon/viewer/backend/models/chameleon_distributed.py
+++ b/chameleon/viewer/backend/models/chameleon_distributed.py
@@ -20,8 +20,9 @@ import redis.asyncio as async_redis
 import torch
 from tokenizers import Tokenizer
 
-from chameleon.inference.vocab import VocabInfo
 from chameleon.inference.image_tokenizer import ImageTokenizer
+from chameleon.inference.loader import load_model
+from chameleon.inference.vocab import VocabInfo
 from chameleon.viewer.backend.data_types import WSMessageType
 from chameleon.viewer.backend.models.abstract_model import (
     DEFAULT_IMAGE_CFG_IMAGE,
@@ -32,9 +33,11 @@ from chameleon.viewer.backend.models.abstract_model import (
     MixedSequenceType,
     StreamingImage,
 )
-from chameleon.viewer.backend.models.chameleon_local import ChameleonForwardMixin, ChameleonTokenizationMixin
+from chameleon.viewer.backend.models.chameleon_local import (
+    ChameleonForwardMixin,
+    ChameleonTokenizationMixin,
+)
 from chameleon.viewer.backend.utils import get_logger
-from chameleon.inference.loader import load_model
 
 logger = get_logger(__name__)
 

--- a/chameleon/viewer/backend/models/chameleon_local.py
+++ b/chameleon/viewer/backend/models/chameleon_local.py
@@ -20,6 +20,8 @@ from transformers import (
 
 from chameleon.inference.alignment import AlignPromptRight
 from chameleon.inference.generation import ChameleonGenerator
+from chameleon.inference.image_tokenizer import ImageTokenizer
+from chameleon.inference.loader import load_model
 from chameleon.inference.logits_processor import (
     AllowOnlyTokensAfterIndexLogitsProcessor,
     AllowOnlyTokensLogitsProcessor,
@@ -32,8 +34,6 @@ from chameleon.inference.token_selector import (
     ReplicatedInputTokenSelector,
 )
 from chameleon.inference.vocab import VocabInfo, VocabTranslation
-from chameleon.inference.loader import load_model
-from chameleon.inference.image_tokenizer import ImageTokenizer
 from chameleon.viewer.backend.models.abstract_model import (
     DEFAULT_IMAGE_CFG_IMAGE,
     DEFAULT_IMAGE_CFG_TEXT,


### PR DESCRIPTION
- 1 - Remove unused imports.
- 2 - Use `isinstance()` instead of `if type(value) == type:`
- 3 - Use `if variable is True:` instead of `if veriable == True:`
- 4 - Reformat import modules using ruff.