### PR TITLE
Make Redis host configurable

### DIFF
--- a/chameleon/viewer/backend/model_viewer.py
+++ b/chameleon/viewer/backend/model_viewer.py
@@ -34,7 +34,8 @@ def create_chameleon_generator(cfg: DictConfig):
             world_size=world_size,
             master_address=cfg.distributed.master_address,
             master_port=cfg.distributed.master_port,
-            redis_port=cfg.redis_port,
+            redis_host=cfg.redis.host,
+            redis_port=cfg.redis.port,
         )
     else:
         generator = ChameleonLocalGenerator(
@@ -58,7 +59,8 @@ def main(cfg: DictConfig) -> None:
         cfg.host,
         cfg.port,
         debug=cfg.debug,
-        redis_port=cfg.redis_port,
+        redis_host=cfg.redis.host,
+        redis_port=cfg.redis.port,
     )
 
 

--- a/chameleon/viewer/backend/models/chameleon_distributed.py
+++ b/chameleon/viewer/backend/models/chameleon_distributed.py
@@ -316,10 +316,11 @@ def distributed_workers(
     master_port: str,
     world_size: int,
     rank: int,
+    redis_host: str,
     redis_port: int,
     worker_queues: dict[int, multiprocessing.Queue],
 ) -> None:
-    redis_client = redis.Redis("redis", redis_port)
+    redis_client = redis.Redis(redis_host, redis_port)
     request_queue = RedisQueue(redis_client, "request")
     response_queue = RedisQueue(redis_client, "response")
 
@@ -522,6 +523,7 @@ class ChameleonDistributedGenerator(AbstractMultimodalGenerator, ChameleonTokeni
         vqgan_ckpt_path: str | None = None,
         master_address: str = "0.0.0.0",
         additional_eos_tokens: list[str] | None = None,
+        redis_host: str = "redis",
         redis_port: int | None = None,
     ) -> None:
         self.master_port = master_port
@@ -534,9 +536,10 @@ class ChameleonDistributedGenerator(AbstractMultimodalGenerator, ChameleonTokeni
 
         logger.info("Loading VQGAN...")
         self.image_tokenizer = ImageTokenizer(vqgan_config_path, vqgan_ckpt_path)
+        self.redis_host = redis_host
         self.redis_port = redis_port
         self.redis_pool = async_redis.ConnectionPool.from_url(
-            f"redis://redis:{redis_port}"
+            f"redis://{redis_host}:{redis_port}"
         )
         self.redis_client = async_redis.Redis.from_pool(self.redis_pool)
         self.request_queue = AsyncRedisQueue(self.redis_client, "request")
@@ -562,6 +565,7 @@ class ChameleonDistributedGenerator(AbstractMultimodalGenerator, ChameleonTokeni
                     master_port,
                     world_size,
                     i,
+                    self.redis_host,
                     self.redis_port,
                     self.worker_queues,
                 ),

--- a/chameleon/viewer/backend/models/service.py
+++ b/chameleon/viewer/backend/models/service.py
@@ -94,6 +94,7 @@ COORDINATOR = "coordinator"
 def web_app(
     generator: AbstractMultimodalGenerator,
     debug: bool = True,
+    redis_host: str = "redis",
     redis_port: int | None = None,
 ) -> FastAPI:
     app = FastAPI(debug=debug)
@@ -102,7 +103,7 @@ def web_app(
         redis_lock = None
         queue_counter = None
     else:
-        redis_client = async_redis.Redis.from_url(f"redis://redis:{redis_port}")
+        redis_client = async_redis.Redis.from_url(f"redis://{redis_host}:{redis_port}")
         redis_lock = async_redis.lock.Lock(redis_client, COORDINATOR)
         queue_counter = AsyncRedisCounter(redis_client, "count_pending")
     hostname = socket.gethostname()
@@ -292,9 +293,10 @@ def serve(
     host: str,
     port: int,
     debug: bool = True,
+    redis_host: str = "redis",
     redis_port: int | None = None,
 ) -> None:
-    app = web_app(model, debug=debug, redis_port=redis_port)
+    app = web_app(model, debug=debug, redis_host=redis_host, redis_port=redis_port)
     # TODO: convert this to a subprocess call so enable more
     # uvicorn features like multiple workers
     uvicorn.run(app, host=host, port=port)

--- a/config/model_viewer.yaml
+++ b/config/model_viewer.yaml
@@ -20,4 +20,6 @@ distributed:
   master_address: "0.0.0.0"
   master_port: 12332
 
-redis_port: 6379
+redis:
+  host: redis
+  port: 6379


### PR DESCRIPTION
Currently, the host for the redis service is hard-coded to `redis` several places in the code.  This prevents the project from being configured to run outside of `docker compose` as the `redis` network does not exist.

This PR adds a `redis.host` variable to the hydra config to allow it to be overridden. 

Usage:

```
python -m chameleon.viewer.backend.model_viewer redis.host=my_host
```