### PR TITLE
Add egg directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.pyc
 
 /outputs
+/chameleon.egg-info


### PR DESCRIPTION
This PR adds the egg-info directory to the gitignore.

According to the [README](https://github.com/facebookresearch/chameleon?tab=readme-ov-file#getting-started), the project shoudl be installed with `pip install -e .`.  This command generates this directory, which should be ignored and not checked into version control. 