### PR TITLE
Allow frontend WS address to be configured

### DIFF
--- a/chameleon/viewer/frontend/src/Config.ts
+++ b/chameleon/viewer/frontend/src/Config.ts
@@ -6,6 +6,6 @@
 */
 
 export const Config = {
-  ws_address: "ws://0.0.0.0:7102",
+  ws_address: import.meta.env.VITE_WS_ADDRESS || "ws://0.0.0.0:7102",
   default_seed: 97,
 };


### PR DESCRIPTION
This PR allows the websocket of the FE react app to be configured by an environment variable `VITE_WS_ADDRESS`.  This will enable deployments of the service outside of localhost

Usage:

```
export VITE_WS_ADDRESS=wss://myservice.com
npm run dev
```